### PR TITLE
Enable strict mode, support node 4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/code
   docker:
-    - image: circleci/node:8
+    - image: circleci/node:4
       environment:
         NPM_CONFIG_LOGLEVEL: error # make npm commands less noisy
         JOBS: max # https://gist.github.com/ralphtheninja/f7c45bdee00784b41fed

--- a/index.js
+++ b/index.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+'use strict'
+
 const prog = require('caporal')
 const acorn = require('acorn')
 const glob = require('glob')

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "caporal": "^0.7.0"
   },
   "engines": {
-    "node": ">= 7"
+    "node": ">= 4"
   },
   "keywords": [
     "check for es6",

--- a/test.js
+++ b/test.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const exec = require('child_process').exec
 const globby = require('globby')
 const assert = require('assert')


### PR DESCRIPTION
With almost no code change, this module can be used with node v4:
```
λ node --version
v4.2.0

λ npm test

> es-check@1.0.0 test E:\Projects\repos\es-check
> nyc mocha test.js --timeout 10s --coverage



  √ �  Es Check should pass when checking an array of es5 files as es5 (5972ms)

 es-check: error in: ./tests/es6.js

 es-check: error in: ./tests/es6-2.js

  √ �  Es Check should fail when checking an array of es6 files as es5 (2846ms)
  √ �  Es Check should pass when checking a glob of es6 files  (2818ms)

 es-check: error in: ./tests/es6-2.js

 es-check: error in: ./tests/es6.js

  √ �  Es Check should fail when checking a glob of es5 files (2797ms)

  4 passing (14s)

----------|----------|----------|----------|----------|----------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
----------|----------|----------|----------|----------|----------------|
All files |     61.7 |    30.77 |      100 |     61.7 |                |
 index.js |     61.7 |    30.77 |      100 |     61.7 |... 65,66,68,96 |
----------|----------|----------|----------|----------|----------------|
```

#### Code Changelog
- Enable strict mode in `index.js` and `test.js`, required for block-scoped
  declarations
- Change `package.json>engines>node` from 7 to 4
- Test on node 4 in CircleCI