### PR TITLE
[fix] set glob opt nodir true

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const exec = require('child_process').exec
-const globby = require('globby')
 const assert = require('assert')
 
 it('🎉  Es Check should pass when checking an array of es5 files as es5', (done) => {

--- a/tests/pkg.js/es5.js
+++ b/tests/pkg.js/es5.js
@@ -1,0 +1,7 @@
+function test() {
+	var afunc = function() {};
+	afunc();
+	function bfunc() {}
+	bfunc();
+}
+test();


### PR DESCRIPTION
Right now, if a folder's name matches `*.js`, it results in the following error:

```
fs.js:682
  return binding.read(fd, buffer, offset, length, position);
                 ^

Error: EISDIR: illegal operation on a directory, read
    at Object.fs.readSync (fs.js:682:18)
    at tryReadSync (fs.js:543:20)
    at Object.fs.readFileSync (fs.js:586:19)
    at globbedFiles.forEach.file (E:\Projects\repos\es-check\index.js:11:175)
    at Array.forEach (<anonymous>)
    at files.forEach.pattern (E:\Projects\repos\es-check\index.js:11:100)
    at Array.forEach (<anonymous>)
    at Command.prog.version.command.alias.argument.argument.action [as _action] (E:\Projects\repos\es-check\index.js:10:1109)
    at Command._run (E:\Projects\repos\es-check\node_modules\caporal\lib\command.js:407:40)
    at Program._run (E:\Projects\repos\es-check\node_modules\caporal\lib\program.js:156:16)
    at Program.parse (E:\Projects\repos\es-check\node_modules\caporal\lib\program.js:259:17)
    at Object.<anonymous> (E:\Projects\repos\es-check\index.js:11:914)
```
This PR fixes the issue by setting the appropriate glob option to remove directories from the files returned.

### Code changelog
- Pass `nodir: true` in glob options.
- Add test fixture, folder with name `pkg.js`
- Minor refactoring

P.S: Let me know if you want me to remove any of the refactorings.