### PR TITLE
[fix] declare files attr in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.5",
   "description": "Checks the EcamScript version of .js glob against a specified version of EcamScript with a shell command",
   "main": "index.js",
+  "files": [
+    "index.js"
+  ],
   "bin": "index.js",
   "scripts": {
     "lint": "eslint index.js --fix",


### PR DESCRIPTION
Right now, the npm package has the following files:
```
λ tree node_modules\es-check\
node_modules\es-check\
|-- CODEOWNERS
|-- LICENSE
|-- README.md
|-- index.js
|-- node_modules
|-- package-lock.json
|-- package.json
|-- test.js
`-- tests
    |-- es5-2.js
    |-- es5.js
    |-- es6-2.js
    |-- es6.js
    `-- pkg.js
        `-- es5.js

```
By declaring the `files` entry in package.json, we can avoid shipping useless files in the npm package.
Docs link - https://docs.npmjs.com/files/package.json#files
