### PR TITLE
add support for ES modules using --module true flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,12 @@ index.js es-check <es-version> [files...]
 
 ```
 
+### Options
+
+```sh
+--module <true|false>   uses ES modules, default false
+```
+
 ### Global Options
 
 ```sh
@@ -154,6 +160,7 @@ Here's an example of what an `.escheckrc` file will look like:
 ```json
 {
   "ecmaVersion": "es6",
+  "module": false,
   "files": "./dist/**/*.js"
 }
 ```

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ const argsArray = process.argv
 */
 prog
   .version(pkg.version)
+  .option('--module <true|false>', 'uses ES modules, default false', prog.BOOL)
   .argument(
     '[ecmaVersion]',
     'define the EcmaScript version to check for against a glob of JavaScript files'
@@ -31,7 +32,7 @@ prog
 
     const configFilePath = path.resolve(process.cwd(), '.escheckrc')
 
-    let v, files, e
+    let v, files, e, esmodule
     let config = {}
 
     /**
@@ -49,6 +50,10 @@ prog
     files = args.files
       ? args.files
       : config.files
+
+    esmodule = options.module 
+      ? options.module
+      : config.module
 
     if (!v) {
       logger.error(
@@ -99,6 +104,7 @@ prog
     const errArray = []
     const globOpts = { nodir: true }
     const acornOpts = { ecmaVersion: e, silent: true }
+    if (esmodule) { acornOpts.sourceType = 'module'}
 
     files.forEach((pattern) => {
       /**

--- a/test.js
+++ b/test.js
@@ -45,6 +45,27 @@ it('👌  Es Check should fail when checking a glob of es5 files', (done) => {
   })
 })
 
+it('👌  Es Check should fail when checking a glob of es6 modules without --module true', (done) => {
+  exec('node index.js es6 ./tests/modules/*.js', (err, stdout, stderr) => {
+    assert(err)
+    console.log(stdout)
+    done()
+  })
+})
+
+it('🎉  Es Check should pass when checking a glob of es6 modules using the --module true flag', (done) => {
+  exec('node index.js --module true es6 ./tests/modules/*.js', (err, stdout, stderr) => {
+    if (err) {
+      console.error(err.stack)
+      console.error(stdout.toString())
+      console.error(stderr.toString())
+      done(err)
+      return
+    }
+    done()
+  })
+})
+
 it('👌 Es Check should read from an .escheckrc file for config', (done) => {
   exec('node index.js', (err, stdout, stderr) => {
     if (err) {

--- a/tests/modules/es6-module.js
+++ b/tests/modules/es6-module.js
@@ -1,0 +1,1 @@
+export const modfunc = () => {};


### PR DESCRIPTION
Enable ES module parsing when either:

 - `--module true` is supplied on the command line
 - `"module": true` is supplied in .escheckrc

By default ES module parsing is false.

## Fixes

- Fixes #49 
