### PR TITLE
Update acorn dependency for security updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "nyc": "^14.1.1"
   },
   "dependencies": {
-    "acorn": "6.1.1",
+    "acorn": "^6.4.1",
     "caporal": "1.3.0",
     "glob": "^7.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -102,13 +102,14 @@ acorn-jsx@^4.1.1:
   dependencies:
     acorn "^5.0.3"
 
-acorn@6.1.1:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.1.1.tgz#7d25ae05bb8ad1f9b699108e1094ecd7884adc1f"
-
 acorn@^5.0.3, acorn@^5.6.0:
   version "5.7.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.3.tgz#67aa231bf8812974b85235a96771eb6bd07ea279"
+
+acorn@^6.4.1:
+  version "6.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
+  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
 
 add-stream@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
es-check pins the acorn dependency to 6.1.1, which has a security issue:
https://www.npmjs.com/advisories/1488

You'd have to run untrusted user input through es-check for this to potentially be an issue, so I'm not sure how likely that is. However, it would still be nice to get this patched and a new version of `es-check` released so that this doesn't cause issues in `npm audit/yarn audit` types of vulnerability reports whenever `es-check` is used.

## Proposed Changes

- Update the `acorn` dependency requirement from `6.1.1` to `^6.4.1`. Versions 6.4.1 or 7.1.1 and later of acorn are patched. I thought it might be beneficial to loosen the version constraint at the same time, so potentially future patches on the 6.x series could automatically be upgraded, rather than requiring explicit upgrades on es-check's part. But let me know if you'd prefer keeping it pinned to an exact version, and happy to update this pull request.

Thanks!