### PR TITLE
feat(index.js): supports printing source code logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ const acorn = require('acorn')
 const glob = require('glob')
 const fs = require('fs')
 const path = require('path')
+const { printSourceCodeInfo } = require('source-map-to-code')
 
 const pkg = require('./package.json')
 const argsArray = process.argv
@@ -188,19 +189,24 @@ prog
     if (errArray.length > 0) {
       logger.error(`ES-Check: there were ${errArray.length} ES version matching errors.`)
       errArray.forEach((o) => {
-        logger.info(`
-          ES-Check Error:
-          ----
-          · erroring file: ${o.file}
-          · error: ${o.err}
-          · see the printed err.stack below for context
-          ----\n
-          ${o.stack}
-        `)
+        printSourceCodeInfo({
+          filePath: o.file,
+          position: o.err.loc
+        }, logger.info).then(() => {
+          logger.info(`
+            ES-Check Error:
+            ----
+            · erroring file: ${o.file}
+            · error: ${o.err}
+            · see the printed err.stack below for context
+            ----\n
+            ${o.stack}
+          `)
+        })
       })
-      process.exit(1)
+    } else {
+      logger.error(`ES-Check: there were no ES version matching errors!  🎉`)
     }
-    logger.error(`ES-Check: there were no ES version matching errors!  🎉`)
   })
 
 prog.parse(argsArray)

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "dependencies": {
     "acorn": "6.1.1",
     "caporal": "1.3.0",
-    "glob": "^7.1.2"
+    "glob": "^7.1.2",
+    "source-map-to-code": "1.0.0"
   },
   "engines": {
     "node": ">= 4"


### PR DESCRIPTION
## why
> I'm a user of this library. I often find it hard to locate the source code, so I want to add this function

## after
```
$ es-check es5 ./build/static/js/main.4e7cf41f.js
ES-Check: there were 1 ES version matching errors.
2  var isTest = true
3  const version = window.version   <------ Error(3:0)
4  console.log(version)

            ES-Check Error:
            ----
            · erroring file: ./build/static/js/main.4e7cf41f.js
            · error: SyntaxError: The keyword 'const' is reserved (1:44871)
            · see the printed err.stack below for context
            ----

            SyntaxError: The keyword 'const' is reserved (1:44871)
    at Parser.pp$4.raise (/Users/xxxx/Work/me/es-check/node_modules/_acorn@6.1.1@acorn/dist/acorn.js:2844:13)
```